### PR TITLE
iCANS missing bits

### DIFF
--- a/qiskit/algorithms/__init__.py
+++ b/qiskit/algorithms/__init__.py
@@ -230,6 +230,7 @@ from .minimum_eigen_solvers import (
     VQE,
     VQEResult,
     QAOA,
+    ICANS,
     NumPyMinimumEigensolver,
     MinimumEigensolver,
     MinimumEigensolverResult,

--- a/qiskit/algorithms/minimum_eigen_solvers/__init__.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/__init__.py
@@ -13,6 +13,7 @@
 """ Minimum Eigen Solvers Package """
 
 from .vqe import VQE, VQEResult
+from .vqe_icans import ICANS
 from .qaoa import QAOA
 from .numpy_minimum_eigen_solver import NumPyMinimumEigensolver
 from .minimum_eigen_solver import MinimumEigensolver, MinimumEigensolverResult
@@ -20,6 +21,7 @@ from .minimum_eigen_solver import MinimumEigensolver, MinimumEigensolverResult
 __all__ = [
     "VQE",
     "VQEResult",
+    "ICANS",
     "QAOA",
     "NumPyMinimumEigensolver",
     "MinimumEigensolver",

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe_icans.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe_icans.py
@@ -1,42 +1,116 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
-from typing import Optional, List, Callable, Union, Dict, Tuple
+"""VQE optimization with dynamic shot scheduling – ICANS optimizer."""
 
-from qiskit import Aer
-from qiskit.algorithms import VQE, VQEResult
-from qiskit.algorithms.optimizers import SPSA, ADAM
-from qiskit.circuit.library import EfficientSU2
-from qiskit.opflow import X, Y, Z, I, StateFn
-from qiskit import Aer, transpile, assemble
-from qiskit.circuit.library import RealAmplitudes
-from qiskit.opflow import PauliSumOp
-from qiskit.circuit import QuantumCircuit, Parameter, ParameterVector
-from qiskit.opflow import *
-from qiskit.utils import QuantumInstance
-from qiskit.providers import Backend
-import numpy as np
+from typing import Optional, Callable, Union
 import copy
 from time import time
+import numpy as np
+
+from qiskit.algorithms.list_or_dict import ListOrDict
+from qiskit.algorithms.aux_ops_evaluator import eval_observables
+from qiskit.circuit import QuantumCircuit
+from qiskit.opflow import OperatorBase, PauliExpectation, SummedOp
+from qiskit.utils import QuantumInstance
+from qiskit.providers import Backend
+
+from .vqe import VQE, VQEResult
+from .minimum_eigen_solver import MinimumEigensolverResult
 
 
-##----icans
 class ICANS(VQE):
-    # Init is the same as standard VQE
-    # New parameters will appear at compute_minimum_eigenvalue function
+    """
+    The iCANS algorithm (individual coupled adaptive number of shots) [1], adaptively selects the
+    number of shots in each iteration to reach the target accuracy with minimal number of quantum
+    computational resources, both for a given iteration and for a given partial derivative in a
+    stochastic gradient descent. As an optimization method, it is appropriately suited to noisy
+    situations, when the cost of each shot is expensive.
+
+    ICANS is implemented as a subclass of VQE. VQE [2] is a quantum algorithm that uses a
+    variational technique to find the minimum eigenvalue of the Hamiltonian of a given system.
+    According to Ref. [1], iCANS may perform comparably or better than other state-of-the-art
+    optimizers, and especially well in the presence of realistic hardware noise.
+    There are two variations, iCANS1 and iCANS2. The first is the more aggressive version,
+    in relation to the learning rate, while iCANS2 is more cautious and limits the learning rate
+    so that the expected gain is always guaranteed to be positive.
+
+    Examples::
+
+    This example runs ICANS with some specified parameters and limited learning rate.
+
+    .. code-block::python
+
+        import numpy as np
+
+        from qiskit.algorithms import ICANS
+        from qiskit.circuit.library import EfficientSU2
+        from qiskit import Aer
+
+        backend = Aer.get_backend("qasm_simulator")
+
+        hamiltonian = PauliSumOp.from_list(
+            [
+                ("XXI", 1),
+                ("XIX", 1),
+                ("IXX", 1),
+                ("YYI", 1),
+                ("YIY", 1),
+                ("IYY", 1),
+                ("ZZI", 1),
+                ("ZIZ", 1),
+                ("IZZ", 1),
+                ("IIZ", 3),
+                ("IZI", 3),
+                ("ZII", 3),
+            ]
+        )
+
+        # parameters for iCANS
+        maxiter = 500
+        min_shots = 100
+        alpha = 0.05
+
+        icans = ICANS(ansatz, quantum_instance=backend, min_shots=min_shots, alpha=alpha,
+                      maxiter=maxiter, limit_learning_rate=True)
+
+        result_icans = icans1.compute_minimum_eigenvalue(hamiltonian)
+        print(result_icans)
+
+
+
+    References::
+
+        [1] Jonas M. Kübler, Andrew Arrasmith, Lukasz Cincio, Patrick J. Coles (2019).
+            An Adaptive Optimizer for Measurement-Frugal Variational Algorithms.
+            `arXiv:1909.09082 <https://arxiv.org/abs/1909.09083>`_
+        [2] Alberto Peruzzo, Et al. (2013). A variational eigenvalue solver on a quantum processor.
+            `arXiv:1304.3061 <https://arxiv.org/abs/1304.3061>`_
+
+    """
+
     def __init__(
         self,
         ansatz: Optional[QuantumCircuit] = None,
         initial_point: Optional[np.ndarray] = None,
-        # gradient: Optional[Union[GradientBase, Callable]] = None,
-        max_evals_grouped: int = 1,
         callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
-        quantum_instance: Optional[Union[QuantumInstance, Backend]] = None,        
-        minShots: int =100,
+        quantum_instance: Optional[Union[QuantumInstance, Backend]] = None,
+        min_shots: int = 100,
         alpha: float = 0.01,
-        max_iterations: Optional[int] = 500,
-        L: Optional[float] = None,
-        mu: Optional[float]= 0.99,
-        b: Optional[float] = 0.000001,
-        limit_learning_rate: Optional[bool] = False
+        maxiter: int = 500,
+        lipschitz: Optional[float] = None,
+        mu: float = 0.99,
+        b: float = 1e-6,
+        limit_learning_rate: bool = False,
     ) -> None:
         super().__init__(
             ansatz=ansatz,
@@ -47,10 +121,10 @@ class ICANS(VQE):
             callback=callback,
             quantum_instance=quantum_instance,
         )
-        self.minShots = minShots
+        self.min_shots = min_shots
         self.alpha = alpha
-        self.max_iterations = max_iterations
-        self.L = L
+        self.maxiter = maxiter
+        self.lipschitz = lipschitz
         self.mu = mu
         self.b = b
         self.limit_learning_rate = limit_learning_rate
@@ -58,91 +132,80 @@ class ICANS(VQE):
     def single_shots(
         self, expectation: OperatorBase, values: np.ndarray, num_shots: int
     ) -> np.ndarray:
-        # set the number of shots to the current value
+        """Do single shots"""
+        # set the number of shots in the quantum instance
         self._circuit_sampler.quantum_instance.run_config.shots = num_shots
+
+        # evaluate the circuits
         param_dict = dict(zip(self.ansatz.parameters, values))
-        
+
         sampled = self._circuit_sampler.convert(expectation, params=param_dict)
+
         if not isinstance(sampled, SummedOp):
             sampled = SummedOp([sampled])
 
-        n_components = len(sampled.oplist)
-        out_Result = []
-        for comp in range(n_components):
+        # evaluate each Pauli group
+        out = []
+        for component in sampled.oplist:
             read_outs = []
-            composed = sampled.oplist[comp]
-            meas2 = composed[0]
-            samples2 = composed[1]
-            
-            for state, amplitude in samples2.primitive.items():
+            measurement, samples = component
+
+            for state, amplitude in samples.primitive.items():
                 occurence = int(np.round(num_shots * np.abs(amplitude) ** 2))
-                value = np.real(meas2.eval(state))
+                value = np.real(measurement.eval(state))
                 read_outs += occurence * [value]
-                
-            out_Result.append(read_outs)
-            
-        # Sum the components and return
-        out = np.array(out_Result)
-        
-        return np.array(out.sum(axis=0))
-    
+
+            out.append(read_outs)
+
+        return np.array(out).sum(axis=0)
+
     def compute_minimum_eigenvalue(
-        self,
-        operator
-    ):
-        # Execute optimization by iCans method
-        # limit_learning_rate = Falsefor iCans1, True for iCans2
+        self, operator: OperatorBase, aux_operators: Optional[ListOrDict[OperatorBase]] = None
+    ) -> MinimumEigensolverResult:
         start_time = time()
 
-        epsilon = np.pi / 2  # Parameter shift rule
-        
+        epsilon = np.pi / 2  # Parameter shift rule shifts the parameter values by pi/2
         n_param = self.ansatz.num_parameters
-        
+
         if self.initial_point is None:
             lst_param = 2 * np.pi * np.random.rand(n_param)
         else:
             lst_param = self.initial_point
 
-        # Define Lipschitz constant
-        if self.L is None:
-            # H = a*X + b*Z,
-            # where X and Z are Pauli operators. The eigenvalues of X and Z are both {1, -1}, so the eigenvalues of a*X are {a, -a} and of b*Z are {b, -b}. Then we compute the upper bound for the Lipschitz constant from Eq. (5) as
-            # L <= |a| + |b|.
-            # :: self.L = np.sum(np.abs(self.operator.coeffs))
-            self.L = np.sum(np.abs(operator.coeffs))
-        
+        if self.lipschitz is None:
+            lipschitz = np.sum(np.abs(operator.coeffs))
+        else:
+            lipschitz = self.lipschitz
+
         expectation = self.construct_expectation(self.ansatz.parameters, operator)
-        
-        shots = np.zeros(n_param) + self.minShots  # Initial vector with number of shots
-        self.hist_shots = np.zeros(self.max_iterations)  # historic total shots
-        self.hist_results = np.zeros(self.max_iterations)  # historic partial results        
-        xi = np.zeros(n_param)  # Variances
-        chi = np.zeros(n_param)  # gradients
-        gamma = np.zeros(n_param)  # Expected gain
-        
-        for k in range(self.max_iterations):
+        energy_evaluation = self.get_energy_evaluation(operator)
+
+        # algorithm variables (number of shots, estimated average, variance, ...)
+        shots = np.zeros(n_param) + self.min_shots
+        xi = np.zeros(n_param)
+        chi = np.zeros(n_param)
+        gamma = np.zeros(n_param)
+
+        # keep track of the total number of shots taken
+        shots_history = np.empty(self.maxiter)
+
+        for k in range(self.maxiter):
             grad = np.zeros(n_param)
             variances = np.zeros(n_param)
-            
+
             # Calculation of gradients
             for param in range(n_param):
                 parameters_plus = copy.deepcopy(lst_param)
                 parameters_plus[param] += epsilon
-                
-                results_plus = self.single_shots(
-                    expectation, parameters_plus, shots[param]
-                )
-                
+
+                results_plus = self.single_shots(expectation, parameters_plus, shots[param])
+
                 parameters_minus = copy.deepcopy(lst_param)
                 parameters_minus[param] -= epsilon
-                
-                results_minus = self.single_shots(
-                    expectation, parameters_minus, shots[param]
-                )
-                
-                grad[param] = (
-                    np.average(results_plus) - np.average(results_minus)
-                ) / 2
+
+                results_minus = self.single_shots(expectation, parameters_minus, shots[param])
+
+                grad[param] = (np.average(results_plus) - np.average(results_minus)) / 2
                 variances[param] = np.var(results_plus + results_minus)
 
             # Update gradient
@@ -150,70 +213,70 @@ class ICANS(VQE):
                 lst_param = lst_param - self.alpha * grad
             else:
                 alpha_bound = grad[param] ** 2 / (
-                        self.L
-                        * (
-                            grad[param] ** 2
-                            + variances[param] / shots[param]
-                            + self.b * self.mu**k
-                        )
-                    )
-                if self.alpha <=alpha_bound:
-                    lst_param = lst_param - self.alpha * grad
-                else:
-                    lst_param = lst_param - alpha_bound * grad                    
-            
-            # Saves the historic of results
-            self.hist_results[k] = np.average(results_plus)
+                    lipschitz
+                    * (grad[param] ** 2 + variances[param] / shots[param] + self.b * self.mu**k)
+                )
+                lst_param = lst_param - min(self.alpha, alpha_bound) * grad
+
+            if self.callback is not None:
+                # the energy evaluation function forwards the information to the callback
+                _ = energy_evaluation(lst_param)
+
             # Saves the accumulated shots
             if k >= 1:
-                self.hist_shots[k] = self.hist_shots[k - 1] + 2 * shots.sum()
+                shots_history[k] = shots_history[k - 1] + 2 * shots.sum()
             else:
-                self.hist_shots[k] = 2 * shots.sum()
+                shots_history[k] = 2 * shots.sum()
+
             # Update number of shots
-            for param, s in enumerate(shots):
+            for param, _ in enumerate(shots):
                 xi_aux = self.mu * xi[param] + (1 - self.mu) * variances[param]
                 chi_aux = self.mu * chi[param] + (1 - self.mu) * grad[param]
-                
+
                 xi[param] = xi_aux / (1 - self.mu ** (k + 1))
                 chi[param] = chi_aux / (1 - self.mu ** (k + 1))
-                
+
                 shots[param] = np.ceil(
                     2
-                    * self.L
+                    * lipschitz
                     * self.alpha
-                    / (2 - self.L * self.alpha)
+                    / (2 - lipschitz * self.alpha)
                     * xi[param]
                     / (chi[param] ** 2 + self.b * self.mu**k)
                 )
-                if shots[param] < self.minShots:
-                    shots[param] = self.minShots
-                    
+                if shots[param] < self.min_shots:
+                    shots[param] = self.min_shots
+
             # Expected return
             for i in range(n_param):
                 gamma[i] = (
-                    (self.alpha - self.L * self.alpha**2 / 2) * chi[i] ** 2
-                    - self.L * self.alpha**2 * xi[i] / (2 * shots[i])
+                    (self.alpha - lipschitz * self.alpha**2 / 2) * chi[i] ** 2
+                    - lipschitz * self.alpha**2 * xi[i] / (2 * shots[i])
                 ) / shots[i]
             idx = gamma.argmax(axis=0)
             smax = shots[idx]
-            
+
             # Clip shots
             for param in range(n_param):
                 if shots[param] > smax:
                     shots[param] = smax
-        # print("Historic number shots: ", hist_shots)
-        # print("Total shots: ", hist_shots.sum())
-        
+
         eval_time = time() - start_time
 
         result = VQEResult()
         result.optimal_point = lst_param
         result.optimal_parameters = dict(zip(self.ansatz.parameters, lst_param))
-        result.optimal_value = self.hist_results[self.max_iterations-1]
-        result.cost_function_evals = 2*n_param*self.max_iterations
+        result.optimal_value = energy_evaluation(lst_param)
+        result.cost_function_evals = 2 * n_param * self.maxiter
         result.optimizer_time = eval_time
-        result.eigenvalue =self.hist_results[self.max_iterations-1] + 0j
+        result.eigenvalue = result.optimal_value + 0j
         result.eigenstate = self._get_eigenstate(result.optimal_parameters)
-        result.total_shots = self.hist_shots[self.max_iterations-1]
+        result.total_shots = shots_history[-1]
+
+        # calculate the expectation values of the aux operators if they are provided
+        if aux_operators is not None:
+            bound = self.ansatz.assign_parameters(result.optimal_point)
+            aux_values = eval_observables(self.quantum_instance, bound, aux_operators, expectation)
+            result.aux_operator_eigenvalues = aux_values
 
         return result

--- a/test/python/algorithms/minimum_eigen_solvers/test_icans.py
+++ b/test/python/algorithms/minimum_eigen_solvers/test_icans.py
@@ -1,0 +1,51 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test iCANS."""
+
+import unittest
+from test.python.algorithms import QiskitAlgorithmsTestCase
+
+from qiskit.algorithms import ICANS
+from qiskit.circuit.library import EfficientSU2
+from qiskit.opflow import X, I, Z
+from qiskit.providers.basicaer import QasmSimulatorPy
+from qiskit.providers.aer import QasmSimulator
+
+
+class TestICANS(QiskitAlgorithmsTestCase):
+    """Test iCANS"""
+
+    def setUp(self):
+        super().setUp()
+        self.backend = QasmSimulator()
+
+    def test_simple_run(self):
+        """Test a simple iCANS run."""
+
+        hamiltonian = (X ^ I) + (I ^ X) - 0.1 * (Z ^ Z)
+        ansatz = EfficientSU2(num_qubits=2, reps=1)
+
+        history = []
+
+        def store_history(*args):
+            print(args)
+            history.append(args)
+
+        icans = ICANS(ansatz, min_shots=10, quantum_instance=self.backend, callback=store_history)
+        result = icans.compute_minimum_eigenvalue(hamiltonian)
+
+        print(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/algorithms/minimum_eigen_solvers/test_numpy_minimum_eigen_solver.py
+++ b/test/python/algorithms/minimum_eigen_solvers/test_numpy_minimum_eigen_solver.py
@@ -1,0 +1,225 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test NumPy Minimum Eigensolver """
+
+import unittest
+from test.python.algorithms import QiskitAlgorithmsTestCase
+
+import numpy as np
+from ddt import ddt, data
+
+from qiskit.algorithms import NumPyMinimumEigensolver
+from qiskit.opflow import PauliSumOp, X, Y, Z
+
+
+@ddt
+class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
+    """Test NumPy Minimum Eigensolver"""
+
+    def setUp(self):
+        super().setUp()
+        self.qubit_op = PauliSumOp.from_list(
+            [
+                ("II", -1.052373245772859),
+                ("ZI", 0.39793742484318045),
+                ("IZ", -0.39793742484318045),
+                ("ZZ", -0.01128010425623538),
+                ("XX", 0.18093119978423156),
+            ]
+        )
+
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        self.aux_ops_list = [aux_op1, aux_op2]
+        self.aux_ops_dict = {"aux_op1": aux_op1, "aux_op2": aux_op2}
+
+    def test_cme(self):
+        """Basic test"""
+        algo = NumPyMinimumEigensolver()
+        result = algo.compute_minimum_eigenvalue(
+            operator=self.qubit_op, aux_operators=self.aux_ops_list
+        )
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+
+    def test_cme_reuse(self):
+        """Test reuse"""
+        # Start with no operator or aux_operators, give via compute method
+        algo = NumPyMinimumEigensolver()
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
+        self.assertIsNone(result.aux_operator_eigenvalues)
+
+        # Add aux_operators and go again
+        result = algo.compute_minimum_eigenvalue(
+            operator=self.qubit_op, aux_operators=self.aux_ops_list
+        )
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+
+        # "Remove" aux_operators and go again
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=[])
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
+        self.assertIsNone(result.aux_operator_eigenvalues)
+
+        # Set aux_operators and go again
+        result = algo.compute_minimum_eigenvalue(
+            operator=self.qubit_op, aux_operators=self.aux_ops_list
+        )
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+
+        # Finally just set one of aux_operators and main operator, remove aux_operators
+        result = algo.compute_minimum_eigenvalue(operator=self.aux_ops_list[0], aux_operators=[])
+        self.assertAlmostEqual(result.eigenvalue, 2 + 0j)
+        self.assertIsNone(result.aux_operator_eigenvalues)
+
+    def test_cme_filter(self):
+        """Basic test"""
+
+        # define filter criterion
+        # pylint: disable=unused-argument
+        def criterion(x, v, a_v):
+            return v >= -0.5
+
+        algo = NumPyMinimumEigensolver(filter_criterion=criterion)
+        result = algo.compute_minimum_eigenvalue(
+            operator=self.qubit_op, aux_operators=self.aux_ops_list
+        )
+        self.assertAlmostEqual(result.eigenvalue, -0.22491125 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+
+    def test_cme_filter_empty(self):
+        """Test with filter always returning False"""
+
+        # define filter criterion
+        # pylint: disable=unused-argument
+        def criterion(x, v, a_v):
+            return False
+
+        algo = NumPyMinimumEigensolver(filter_criterion=criterion)
+        result = algo.compute_minimum_eigenvalue(
+            operator=self.qubit_op, aux_operators=self.aux_ops_list
+        )
+        self.assertEqual(result.eigenvalue, None)
+        self.assertEqual(result.eigenstate, None)
+        self.assertEqual(result.aux_operator_eigenvalues, None)
+
+    @data(X, Y, Z)
+    def test_cme_1q(self, op):
+        """Test for 1 qubit operator"""
+        algo = NumPyMinimumEigensolver()
+        result = algo.compute_minimum_eigenvalue(operator=op)
+        self.assertAlmostEqual(result.eigenvalue, -1)
+
+    def test_cme_aux_ops_dict(self):
+        """Test dictionary compatibility of aux_operators"""
+        # Start with an empty dictionary
+        algo = NumPyMinimumEigensolver()
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators={})
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertIsNone(result.aux_operator_eigenvalues)
+
+        # Add aux_operators dictionary and go again
+        result = algo.compute_minimum_eigenvalue(
+            operator=self.qubit_op, aux_operators=self.aux_ops_dict
+        )
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
+
+        # Add None and zero operators and go again
+        extra_ops = {"None_op": None, "zero_op": 0, **self.aux_ops_dict}
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
+        self.assertEqual(result.aux_operator_eigenvalues["zero_op"], (0.0, 0))
+
+    def test_aux_operators_list(self):
+        """Test list-based aux_operators."""
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_ops = [aux_op1, aux_op2]
+        algo = NumPyMinimumEigensolver()
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+
+        # Go again with additional None and zero operators
+        extra_ops = [*aux_ops, None, 0]
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 4)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+        self.assertIsNone(result.aux_operator_eigenvalues[2], None)
+        self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+        self.assertEqual(result.aux_operator_eigenvalues[3][1], 0.0)
+
+    def test_aux_operators_dict(self):
+        """Test dict-based aux_operators."""
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
+        algo = NumPyMinimumEigensolver()
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+
+        # Go again with additional None and zero operators
+        extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
+        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+        self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
+        self.assertTrue("None_operator" not in result.aux_operator_eigenvalues.keys())
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][1], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/algorithms/minimum_eigen_solvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigen_solvers/test_vqe.py
@@ -1,0 +1,747 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test VQE """
+
+import logging
+import unittest
+from test.python.algorithms import QiskitAlgorithmsTestCase
+from test.python.transpiler._dummy_passes import DummyAP
+
+from functools import partial
+import numpy as np
+from scipy.optimize import minimize as scipy_minimize
+from ddt import data, ddt, unpack
+
+from qiskit import BasicAer, QuantumCircuit
+from qiskit.algorithms import VQE, AlgorithmError
+from qiskit.algorithms.optimizers import (
+    CG,
+    COBYLA,
+    L_BFGS_B,
+    P_BFGS,
+    QNSPSA,
+    SLSQP,
+    SPSA,
+    TNC,
+    OptimizerResult,
+)
+from qiskit.circuit.library import EfficientSU2, RealAmplitudes, TwoLocal
+from qiskit.exceptions import MissingOptionalLibraryError
+from qiskit.opflow import (
+    AerPauliExpectation,
+    Gradient,
+    I,
+    MatrixExpectation,
+    PauliExpectation,
+    PauliSumOp,
+    PrimitiveOp,
+    TwoQubitReduction,
+    X,
+    Z,
+)
+from qiskit.quantum_info import Statevector
+from qiskit.transpiler import PassManager, PassManagerConfig
+from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
+from qiskit.utils import QuantumInstance, algorithm_globals, has_aer
+
+if has_aer():
+    from qiskit import Aer
+
+logger = "LocalLogger"
+
+
+class LogPass(DummyAP):
+    """A dummy analysis pass that logs when executed"""
+
+    def __init__(self, message):
+        super().__init__()
+        self.message = message
+
+    def run(self, dag):
+        logging.getLogger(logger).info(self.message)
+
+
+# pylint: disable=invalid-name, unused-argument
+def _mock_optimizer(fun, x0, jac=None, bounds=None) -> OptimizerResult:
+    """A mock of a callable that can be used as minimizer in the VQE."""
+    result = OptimizerResult()
+    result.x = np.zeros_like(x0)
+    result.fun = fun(result.x)
+    result.nit = 0
+    return result
+
+
+@ddt
+class TestVQE(QiskitAlgorithmsTestCase):
+    """Test VQE"""
+
+    def setUp(self):
+        super().setUp()
+        self.seed = 50
+        algorithm_globals.random_seed = self.seed
+        self.h2_op = (
+            -1.052373245772859 * (I ^ I)
+            + 0.39793742484318045 * (I ^ Z)
+            - 0.39793742484318045 * (Z ^ I)
+            - 0.01128010425623538 * (Z ^ Z)
+            + 0.18093119978423156 * (X ^ X)
+        )
+        self.h2_energy = -1.85727503
+
+        self.ryrz_wavefunction = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        self.ry_wavefunction = TwoLocal(rotation_blocks="ry", entanglement_blocks="cz")
+
+        self.qasm_simulator = QuantumInstance(
+            BasicAer.get_backend("qasm_simulator"),
+            shots=1024,
+            seed_simulator=self.seed,
+            seed_transpiler=self.seed,
+        )
+        self.statevector_simulator = QuantumInstance(
+            BasicAer.get_backend("statevector_simulator"),
+            shots=1,
+            seed_simulator=self.seed,
+            seed_transpiler=self.seed,
+        )
+
+    def test_basic_aer_statevector(self):
+        """Test the VQE on BasicAer's statevector simulator."""
+        wavefunction = self.ryrz_wavefunction
+        vqe = VQE(
+            ansatz=wavefunction,
+            optimizer=L_BFGS_B(),
+            quantum_instance=QuantumInstance(
+                BasicAer.get_backend("statevector_simulator"),
+                basis_gates=["u1", "u2", "u3", "cx", "id"],
+                coupling_map=[[0, 1]],
+                seed_simulator=algorithm_globals.random_seed,
+                seed_transpiler=algorithm_globals.random_seed,
+            ),
+        )
+
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        with self.subTest(msg="test eigenvalue"):
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy)
+
+        with self.subTest(msg="test dimension of optimal point"):
+            self.assertEqual(len(result.optimal_point), 16)
+
+        with self.subTest(msg="assert cost_function_evals is set"):
+            self.assertIsNotNone(result.cost_function_evals)
+
+        with self.subTest(msg="assert optimizer_time is set"):
+            self.assertIsNotNone(result.optimizer_time)
+
+    def test_circuit_input(self):
+        """Test running the VQE on a plain QuantumCircuit object."""
+        wavefunction = QuantumCircuit(2).compose(EfficientSU2(2))
+        optimizer = SLSQP(maxiter=50)
+        vqe = VQE(
+            ansatz=wavefunction, optimizer=optimizer, quantum_instance=self.statevector_simulator
+        )
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=5)
+
+    @data(
+        (MatrixExpectation(), 1),
+        (AerPauliExpectation(), 1),
+        (PauliExpectation(), 2),
+    )
+    @unpack
+    def test_construct_circuit(self, expectation, num_circuits):
+        """Test construct circuits returns QuantumCircuits and the right number of them."""
+        try:
+            wavefunction = EfficientSU2(2, reps=1)
+            vqe = VQE(ansatz=wavefunction, expectation=expectation)
+            params = [0] * wavefunction.num_parameters
+            circuits = vqe.construct_circuit(parameter=params, operator=self.h2_op)
+
+            self.assertEqual(len(circuits), num_circuits)
+            for circuit in circuits:
+                self.assertIsInstance(circuit, QuantumCircuit)
+        except MissingOptionalLibraryError as ex:
+            self.skipTest(str(ex))
+            return
+
+    def test_missing_varform_params(self):
+        """Test specifying a variational form with no parameters raises an error."""
+        circuit = QuantumCircuit(self.h2_op.num_qubits)
+        vqe = VQE(ansatz=circuit, quantum_instance=BasicAer.get_backend("statevector_simulator"))
+        with self.assertRaises(RuntimeError):
+            vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+    @data(
+        (SLSQP(maxiter=50), 5, 4),
+        (SPSA(maxiter=150), 2, 2),  # max_evals_grouped=n or =2 if n>2
+    )
+    @unpack
+    def test_max_evals_grouped(self, optimizer, places, max_evals_grouped):
+        """VQE Optimizers test"""
+        vqe = VQE(
+            ansatz=self.ryrz_wavefunction,
+            optimizer=optimizer,
+            max_evals_grouped=max_evals_grouped,
+            quantum_instance=self.statevector_simulator,
+        )
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=places)
+
+    def test_basic_aer_qasm(self):
+        """Test the VQE on BasicAer's QASM simulator."""
+        optimizer = SPSA(maxiter=300, last_avg=5)
+        wavefunction = self.ry_wavefunction
+
+        vqe = VQE(
+            ansatz=wavefunction,
+            optimizer=optimizer,
+            max_evals_grouped=1,
+            quantum_instance=self.qasm_simulator,
+        )
+
+        # TODO benchmark this later.
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        self.assertAlmostEqual(result.eigenvalue.real, -1.86823, places=2)
+
+    def test_qasm_eigenvector_normalized(self):
+        """Test VQE with qasm_simulator returns normalized eigenvector."""
+        wavefunction = self.ry_wavefunction
+        vqe = VQE(ansatz=wavefunction, quantum_instance=self.qasm_simulator)
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        amplitudes = list(result.eigenstate.values())
+        self.assertAlmostEqual(np.linalg.norm(amplitudes), 1.0, places=4)
+
+    @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
+    def test_with_aer_statevector(self):
+        """Test VQE with Aer's statevector_simulator."""
+        backend = Aer.get_backend("aer_simulator_statevector")
+        wavefunction = self.ry_wavefunction
+        optimizer = L_BFGS_B()
+
+        quantum_instance = QuantumInstance(
+            backend,
+            seed_simulator=algorithm_globals.random_seed,
+            seed_transpiler=algorithm_globals.random_seed,
+        )
+        vqe = VQE(
+            ansatz=wavefunction,
+            optimizer=optimizer,
+            max_evals_grouped=1,
+            quantum_instance=quantum_instance,
+        )
+
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+
+    @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
+    def test_with_aer_qasm(self):
+        """Test VQE with Aer's qasm_simulator."""
+        backend = Aer.get_backend("aer_simulator")
+        optimizer = SPSA(maxiter=200, last_avg=5)
+        wavefunction = self.ry_wavefunction
+
+        quantum_instance = QuantumInstance(
+            backend,
+            seed_simulator=algorithm_globals.random_seed,
+            seed_transpiler=algorithm_globals.random_seed,
+        )
+
+        vqe = VQE(
+            ansatz=wavefunction,
+            optimizer=optimizer,
+            expectation=PauliExpectation(),
+            quantum_instance=quantum_instance,
+        )
+
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        self.assertAlmostEqual(result.eigenvalue.real, -1.86305, places=2)
+
+    @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
+    def test_with_aer_qasm_snapshot_mode(self):
+        """Test the VQE using Aer's qasm_simulator snapshot mode."""
+
+        backend = Aer.get_backend("aer_simulator")
+        optimizer = L_BFGS_B()
+        wavefunction = self.ry_wavefunction
+
+        quantum_instance = QuantumInstance(
+            backend,
+            shots=1,
+            seed_simulator=algorithm_globals.random_seed,
+            seed_transpiler=algorithm_globals.random_seed,
+        )
+        vqe = VQE(
+            ansatz=wavefunction,
+            optimizer=optimizer,
+            expectation=AerPauliExpectation(),
+            quantum_instance=quantum_instance,
+        )
+
+        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+
+    @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
+    @data(
+        CG(maxiter=1),
+        L_BFGS_B(maxfun=1),
+        P_BFGS(maxfun=1, max_processes=0),
+        SLSQP(maxiter=1),
+        TNC(maxiter=1),
+    )
+    def test_with_gradient(self, optimizer):
+        """Test VQE using Gradient()."""
+        quantum_instance = QuantumInstance(
+            backend=Aer.get_backend("qasm_simulator"),
+            shots=1,
+            seed_simulator=algorithm_globals.random_seed,
+            seed_transpiler=algorithm_globals.random_seed,
+        )
+        vqe = VQE(
+            ansatz=self.ry_wavefunction,
+            optimizer=optimizer,
+            gradient=Gradient(),
+            expectation=AerPauliExpectation(),
+            quantum_instance=quantum_instance,
+            max_evals_grouped=1000,
+        )
+        vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+    def test_with_two_qubit_reduction(self):
+        """Test the VQE using TwoQubitReduction."""
+        qubit_op = PauliSumOp.from_list(
+            [
+                ("IIII", -0.8105479805373266),
+                ("IIIZ", 0.17218393261915552),
+                ("IIZZ", -0.22575349222402472),
+                ("IZZI", 0.1721839326191556),
+                ("ZZII", -0.22575349222402466),
+                ("IIZI", 0.1209126326177663),
+                ("IZZZ", 0.16892753870087912),
+                ("IXZX", -0.045232799946057854),
+                ("ZXIX", 0.045232799946057854),
+                ("IXIX", 0.045232799946057854),
+                ("ZXZX", -0.045232799946057854),
+                ("ZZIZ", 0.16614543256382414),
+                ("IZIZ", 0.16614543256382414),
+                ("ZZZZ", 0.17464343068300453),
+                ("ZIZI", 0.1209126326177663),
+            ]
+        )
+        tapered_qubit_op = TwoQubitReduction(num_particles=2).convert(qubit_op)
+        for simulator in [self.qasm_simulator, self.statevector_simulator]:
+            with self.subTest(f"Test for {simulator}."):
+                vqe = VQE(
+                    self.ry_wavefunction,
+                    SPSA(maxiter=300, last_avg=5),
+                    quantum_instance=simulator,
+                )
+                result = vqe.compute_minimum_eigenvalue(tapered_qubit_op)
+                energy = -1.868 if simulator == self.qasm_simulator else self.h2_energy
+                self.assertAlmostEqual(result.eigenvalue.real, energy, places=2)
+
+    def test_callback(self):
+        """Test the callback on VQE."""
+        history = {"eval_count": [], "parameters": [], "mean": [], "std": []}
+
+        def store_intermediate_result(eval_count, parameters, mean, std):
+            history["eval_count"].append(eval_count)
+            history["parameters"].append(parameters)
+            history["mean"].append(mean)
+            history["std"].append(std)
+
+        optimizer = COBYLA(maxiter=3)
+        wavefunction = self.ry_wavefunction
+
+        vqe = VQE(
+            ansatz=wavefunction,
+            optimizer=optimizer,
+            callback=store_intermediate_result,
+            quantum_instance=self.qasm_simulator,
+        )
+        vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
+        self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
+        self.assertTrue(all(isinstance(std, float) for std in history["std"]))
+        for params in history["parameters"]:
+            self.assertTrue(all(isinstance(param, float) for param in params))
+
+    def test_reuse(self):
+        """Test re-using a VQE algorithm instance."""
+        vqe = VQE()
+        with self.subTest(msg="assert running empty raises AlgorithmError"):
+            with self.assertRaises(AlgorithmError):
+                _ = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        vqe.ansatz = ansatz
+        with self.subTest(msg="assert missing operator raises AlgorithmError"):
+            with self.assertRaises(AlgorithmError):
+                _ = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        vqe.expectation = MatrixExpectation()
+        vqe.quantum_instance = self.statevector_simulator
+        with self.subTest(msg="assert VQE works once all info is available"):
+            result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=5)
+
+        operator = PrimitiveOp(np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 2, 0], [0, 0, 0, 3]]))
+
+        with self.subTest(msg="assert minimum eigensolver interface works"):
+            result = vqe.compute_minimum_eigenvalue(operator=operator)
+            self.assertAlmostEqual(result.eigenvalue.real, -1.0, places=5)
+
+    def test_vqe_optimizer(self):
+        """Test running same VQE twice to re-use optimizer, then switch optimizer"""
+        vqe = VQE(
+            optimizer=SLSQP(),
+            quantum_instance=QuantumInstance(BasicAer.get_backend("statevector_simulator")),
+        )
+
+        def run_check():
+            result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+            self.assertAlmostEqual(result.eigenvalue.real, -1.85727503, places=5)
+
+        run_check()
+
+        with self.subTest("Optimizer re-use"):
+            run_check()
+
+        with self.subTest("Optimizer replace"):
+            vqe.optimizer = L_BFGS_B()
+            run_check()
+
+    @data(MatrixExpectation(), None)
+    def test_backend_change(self, user_expectation):
+        """Test that VQE works when backend changes."""
+        vqe = VQE(
+            ansatz=TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz"),
+            optimizer=SLSQP(maxiter=2),
+            expectation=user_expectation,
+            quantum_instance=BasicAer.get_backend("statevector_simulator"),
+        )
+        result0 = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        if user_expectation is not None:
+            with self.subTest("User expectation kept."):
+                self.assertEqual(vqe.expectation, user_expectation)
+
+        vqe.quantum_instance = BasicAer.get_backend("qasm_simulator")
+
+        # works also if no expectation is set, since it will be determined automatically
+        result1 = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+        if user_expectation is not None:
+            with self.subTest("Change backend with user expectation, it is kept."):
+                self.assertEqual(vqe.expectation, user_expectation)
+
+        with self.subTest("Check results."):
+            self.assertEqual(len(result0.optimal_point), len(result1.optimal_point))
+
+    def test_batch_evaluate_with_qnspsa(self):
+        """Test batch evaluating with QNSPSA works."""
+        ansatz = TwoLocal(2, rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+
+        wrapped_backend = BasicAer.get_backend("qasm_simulator")
+        inner_backend = BasicAer.get_backend("statevector_simulator")
+
+        callcount = {"count": 0}
+
+        def wrapped_run(circuits, **kwargs):
+            kwargs["callcount"]["count"] += 1
+            return inner_backend.run(circuits)
+
+        wrapped_backend.run = partial(wrapped_run, callcount=callcount)
+
+        fidelity = QNSPSA.get_fidelity(ansatz, backend=wrapped_backend)
+        qnspsa = QNSPSA(fidelity, maxiter=5)
+
+        vqe = VQE(
+            ansatz=ansatz,
+            optimizer=qnspsa,
+            max_evals_grouped=100,
+            quantum_instance=wrapped_backend,
+        )
+        _ = vqe.compute_minimum_eigenvalue(Z ^ Z)
+
+        # 1 calibration + 1 stddev estimation + 1 initial blocking
+        # + 5 (1 loss + 1 fidelity + 1 blocking) + 1 return loss + 1 VQE eval
+        expected = 1 + 1 + 1 + 5 * 3 + 1 + 1
+
+        self.assertEqual(callcount["count"], expected)
+
+    def test_set_ansatz_to_none(self):
+        """Tests that setting the ansatz to None results in the default behavior"""
+        vqe = VQE(
+            ansatz=self.ryrz_wavefunction,
+            optimizer=L_BFGS_B(),
+            quantum_instance=self.statevector_simulator,
+        )
+        vqe.ansatz = None
+        self.assertIsInstance(vqe.ansatz, RealAmplitudes)
+
+    def test_set_optimizer_to_none(self):
+        """Tests that setting the optimizer to None results in the default behavior"""
+        vqe = VQE(
+            ansatz=self.ryrz_wavefunction,
+            optimizer=L_BFGS_B(),
+            quantum_instance=self.statevector_simulator,
+        )
+        vqe.optimizer = None
+        self.assertIsInstance(vqe.optimizer, SLSQP)
+
+    def test_optimizer_scipy_callable(self):
+        """Test passing a SciPy optimizer directly as callable."""
+        vqe = VQE(
+            optimizer=partial(scipy_minimize, method="L-BFGS-B", options={"maxiter": 2}),
+            quantum_instance=self.statevector_simulator,
+        )
+        result = vqe.compute_minimum_eigenvalue(Z)
+        self.assertEqual(result.cost_function_evals, 20)
+
+    def test_optimizer_callable(self):
+        """Test passing a optimizer directly as callable."""
+        ansatz = RealAmplitudes(1, reps=1)
+        vqe = VQE(
+            ansatz=ansatz, optimizer=_mock_optimizer, quantum_instance=self.statevector_simulator
+        )
+        result = vqe.compute_minimum_eigenvalue(Z)
+        self.assertTrue(np.all(result.optimal_point == np.zeros(ansatz.num_parameters)))
+
+    def test_aux_operators_list(self):
+        """Test list-based aux_operators."""
+        wavefunction = self.ry_wavefunction
+        vqe = VQE(ansatz=wavefunction, quantum_instance=self.statevector_simulator)
+
+        # Start with an empty list
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=[])
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+        self.assertIsNone(result.aux_operator_eigenvalues)
+
+        # Go again with two auxiliary operators
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_ops = [aux_op1, aux_op2]
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+
+        # Go again with additional None and zero operators
+        extra_ops = [*aux_ops, None, 0]
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 4)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+        self.assertEqual(result.aux_operator_eigenvalues[2][0], 0.0)
+        self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[2][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[3][1], 0.0)
+
+    def test_aux_operators_dict(self):
+        """Test dictionary compatibility of aux_operators"""
+        wavefunction = self.ry_wavefunction
+        vqe = VQE(ansatz=wavefunction, quantum_instance=self.statevector_simulator)
+
+        # Start with an empty dictionary
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators={})
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+        self.assertIsNone(result.aux_operator_eigenvalues)
+
+        # Go again with two auxiliary operators
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+
+        # Go again with additional None and zero operators
+        extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
+        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+        self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
+        self.assertTrue("None_operator" not in result.aux_operator_eigenvalues.keys())
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][1], 0.0)
+
+    def test_aux_operator_std_dev_pauli(self):
+        """Test non-zero standard deviations of aux operators with PauliExpectation."""
+        wavefunction = self.ry_wavefunction
+        vqe = VQE(
+            ansatz=wavefunction,
+            expectation=PauliExpectation(),
+            optimizer=COBYLA(maxiter=0),
+            quantum_instance=self.qasm_simulator,
+        )
+
+        # Go again with two auxiliary operators
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_ops = [aux_op1, aux_op2]
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.6796875, places=6)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.02534712219145965, places=6)
+
+        # Go again with additional None and zero operators
+        aux_ops = [*aux_ops, None, 0]
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 4)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.57421875, places=6)
+        self.assertEqual(result.aux_operator_eigenvalues[2][0], 0.0)
+        self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
+        # # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(
+            result.aux_operator_eigenvalues[1][1], 0.026562146577166837, places=6
+        )
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[2][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[3][1], 0.0)
+
+    @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
+    def test_aux_operator_std_dev_aer_pauli(self):
+        """Test non-zero standard deviations of aux operators with AerPauliExpectation."""
+        wavefunction = self.ry_wavefunction
+        vqe = VQE(
+            ansatz=wavefunction,
+            expectation=AerPauliExpectation(),
+            optimizer=COBYLA(maxiter=0),
+            quantum_instance=QuantumInstance(
+                backend=Aer.get_backend("qasm_simulator"),
+                shots=1,
+                seed_simulator=algorithm_globals.random_seed,
+                seed_transpiler=algorithm_globals.random_seed,
+            ),
+        )
+
+        # Go again with two auxiliary operators
+        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_ops = [aux_op1, aux_op2]
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.6698863565455391, places=6)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0, places=6)
+
+        # Go again with additional None and zero operators
+        aux_ops = [*aux_ops, None, 0]
+        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+        self.assertEqual(len(result.aux_operator_eigenvalues), 4)
+        # expectation values
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.6036400943063891, places=6)
+        self.assertEqual(result.aux_operator_eigenvalues[2][0], 0.0)
+        self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
+        # standard deviations
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0, places=6)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[2][1], 0.0)
+        self.assertAlmostEqual(result.aux_operator_eigenvalues[3][1], 0.0)
+
+    def test_2step_transpile(self):
+        """Test the two-step transpiler pass."""
+        # count how often the pass for parameterized circuits is called
+        pre_counter = LogPass("pre_passmanager")
+        pre_pass = PassManager(pre_counter)
+        config = PassManagerConfig(basis_gates=["u3", "cx"])
+        pre_pass += level_1_pass_manager(config)
+
+        # ... and the pass for bound circuits
+        bound_counter = LogPass("bound_pass_manager")
+        bound_pass = PassManager(bound_counter)
+
+        quantum_instance = QuantumInstance(
+            backend=BasicAer.get_backend("statevector_simulator"),
+            basis_gates=["u3", "cx"],
+            pass_manager=pre_pass,
+            bound_pass_manager=bound_pass,
+        )
+
+        optimizer = SPSA(maxiter=5, learning_rate=0.01, perturbation=0.01)
+
+        vqe = VQE(optimizer=optimizer, quantum_instance=quantum_instance)
+        _ = vqe.compute_minimum_eigenvalue(Z)
+
+        with self.assertLogs(logger, level="INFO") as cm:
+            _ = vqe.compute_minimum_eigenvalue(Z)
+
+        expected = [
+            "pre_passmanager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "bound_pass_manager",
+            "pre_passmanager",
+            "bound_pass_manager",
+        ]
+        self.assertEqual([record.message for record in cm.records], expected)
+
+    def test_construct_eigenstate_from_optpoint(self):
+        """Test constructing the eigenstate from the optimal point, if the default ansatz is used."""
+
+        # use Hamiltonian yielding more than 11 parameters in the default ansatz
+        hamiltonian = Z ^ Z ^ Z
+        optimizer = SPSA(maxiter=1, learning_rate=0.01, perturbation=0.01)
+        quantum_instance = QuantumInstance(
+            backend=BasicAer.get_backend("statevector_simulator"), basis_gates=["u3", "cx"]
+        )
+        vqe = VQE(optimizer=optimizer, quantum_instance=quantum_instance)
+        result = vqe.compute_minimum_eigenvalue(hamiltonian)
+
+        optimal_circuit = vqe.ansatz.bind_parameters(result.optimal_point)
+        self.assertTrue(Statevector(result.eigenstate).equiv(optimal_circuit))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -73,6 +73,7 @@ class TestQAOA(QiskitAlgorithmsTestCase):
             BasicAer.get_backend("statevector_simulator"),
             seed_simulator=self.seed,
             seed_transpiler=self.seed,
+            optimization_level=3,
         )
 
     @idata(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add aux operator evaluation and callback. Also includes some small formatting and changing class variables to local variables where possible 🙂 

### Details and comments

* Ensure that the line length is <= 100
* Use `maxiter` instead of `max_iterations` since that's what we use in all optimizers
* Don't set `self.lipschitz` if it is None, but use a local variable instead 
* Fix typehints (`Optional` means that a value can be `None`, not that there is a default value 🙂)
* The `value_hist` did not actually include the values I think, because we only evaluate the energy at the shifted parameters -- and since our shift is large (pi/2) this is not necessarily close to the true function value. So I removed that 🙂 
